### PR TITLE
4: FROM alpine-node:4

### DIFF
--- a/4/Dockerfile
+++ b/4/Dockerfile
@@ -1,4 +1,4 @@
-FROM mhart/alpine-node:4.2.3
+FROM mhart/alpine-node:4
 
 RUN apk update
 


### PR DESCRIPTION
Our current version of node has some security vulnerabilities -- this change will keep us up to date with the latest LTS.
