### PR TITLE
Add datascience Dockerfile

### DIFF
--- a/6-datascience/Dockerfile
+++ b/6-datascience/Dockerfile
@@ -1,0 +1,27 @@
+FROM node:6
+
+# -------------------------------------
+# https://github.com/ContinuumIO/docker-images/blob/master/anaconda3/Dockerfile
+# -------------------------------------
+ENV LANG=C.UTF-8 LC_ALL=C.UTF-8
+
+RUN apt-get update --fix-missing && apt-get install -y wget bzip2 ca-certificates \
+    libglib2.0-0 libxext6 libsm6 libxrender1 \
+    git mercurial subversion
+
+RUN echo 'export PATH=/opt/conda/bin:$PATH' > /etc/profile.d/conda.sh && \
+    wget --quiet https://repo.continuum.io/archive/Anaconda3-4.3.1-Linux-x86_64.sh -O ~/anaconda.sh && \
+    /bin/bash ~/anaconda.sh -b -p /opt/conda && \
+    rm ~/anaconda.sh
+
+RUN apt-get install -y curl grep sed dpkg && \
+    TINI_VERSION=`curl https://github.com/krallin/tini/releases/latest | grep -o "/v.*\"" | sed 's:^..\(.*\).$:\1:'` && \
+    curl -L "https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini_${TINI_VERSION}.deb" > tini.deb && \
+    dpkg -i tini.deb && \
+    rm tini.deb && \
+    apt-get clean
+
+ENV PATH /opt/conda/bin:$PATH
+
+ENTRYPOINT [ "/usr/bin/tini", "--" ]
+CMD [ "/bin/bash" ]


### PR DESCRIPTION
This PR adds a datascience box to our builds.  It is a debian machine based on the official node 6 build and the officially supported Anaconda 3 build.

https://hub.docker.com/r/_/node/
https://hub.docker.com/r/continuumio/anaconda3/